### PR TITLE
feat(discovery): publish RFC 9727 API catalog at /.well-known/api-catalog

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,6 +87,9 @@
 
     <!-- Manifest for PWA -->
     <link rel="manifest" href="/manifest.json" />
+
+    <!-- RFC 9727 API catalog -->
+    <link rel="api-catalog" href="/.well-known/api-catalog" />
   </head>
   <body>
     <div id="app"></div>

--- a/public/.well-known/api-catalog
+++ b/public/.well-known/api-catalog
@@ -1,0 +1,28 @@
+{
+  "linkset": [
+    {
+      "anchor": "https://api.timdehof.dev/api",
+      "service-desc": [
+        {
+          "href": "https://api.timdehof.dev/api/openapi.json",
+          "type": "application/json",
+          "title": "Unified Portfolio API — OpenAPI 3.1 description"
+        }
+      ],
+      "service-doc": [
+        {
+          "href": "https://api.timdehof.dev/api/docs",
+          "type": "text/html",
+          "title": "Unified Portfolio API — reference documentation"
+        }
+      ],
+      "status": [
+        {
+          "href": "https://api.timdehof.dev/api/health",
+          "type": "application/json",
+          "title": "Unified Portfolio API — health check"
+        }
+      ]
+    }
+  ]
+}

--- a/public/_headers
+++ b/public/_headers
@@ -4,6 +4,13 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Strict-Transport-Security: max-age=31536000; includeSubDomains
 
+# RFC 9727 API catalog. Extensionless, so wrangler uploads it as
+# application/octet-stream — the media type has to be set here.
+/.well-known/api-catalog
+  Content-Type: application/linkset+json
+  Cache-Control: public, max-age=3600
+  Access-Control-Allow-Origin: *
+
 /*.js
   Content-Type: text/javascript
 

--- a/tests/api-catalog.test.ts
+++ b/tests/api-catalog.test.ts
@@ -1,0 +1,88 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Guards the RFC 9727 API catalog served at /.well-known/api-catalog.
+ * https://www.rfc-editor.org/rfc/rfc9727
+ *
+ * These assertions cover the document's shape only. Whether Cloudflare actually
+ * serves it as application/linkset+json can only be proven by a request against
+ * `wrangler dev` or the deployed site.
+ */
+
+const CATALOG_PATH = resolve(__dirname, "../public/.well-known/api-catalog");
+const HEADERS_PATH = resolve(__dirname, "../public/_headers");
+const MEDIA_TYPE = "application/linkset+json";
+
+interface Link {
+  href: string;
+  type?: string;
+  title?: string;
+}
+
+type LinksetEntry = { anchor: string } & Record<string, unknown>;
+
+const catalog = JSON.parse(readFileSync(CATALOG_PATH, "utf8")) as { linkset: LinksetEntry[] };
+const headers = readFileSync(HEADERS_PATH, "utf8");
+
+function linksFor(entry: LinksetEntry, relation: string): Link[] {
+  return entry[relation] as Link[];
+}
+
+describe("api catalog document", () => {
+  it("has a non-empty linkset array", () => {
+    expect(Array.isArray(catalog.linkset)).toBe(true);
+    expect(catalog.linkset.length).toBeGreaterThan(0);
+  });
+
+  it.each(catalog.linkset.map((entry, index) => [index, entry] as const))(
+    "entry %i is a valid API description",
+    (_index, entry) => {
+      expect(typeof entry.anchor).toBe("string");
+      expect(new URL(entry.anchor).protocol).toBe("https:");
+
+      // service-desc and service-doc are required by the task; status is optional
+      // but we publish it, so hold the line on all three.
+      for (const relation of ["service-desc", "service-doc", "status"]) {
+        const links = linksFor(entry, relation);
+
+        expect(Array.isArray(links), `${relation} must be an array`).toBe(true);
+        expect(links.length).toBeGreaterThan(0);
+
+        for (const link of links) {
+          expect(typeof link.href).toBe("string");
+          expect(typeof link.type).toBe("string");
+          expect(new URL(link.href).protocol).toBe("https:");
+        }
+      }
+    },
+  );
+
+  it.each(catalog.linkset.map((entry, index) => [index, entry] as const))(
+    "entry %i keeps every href on the anchor's origin",
+    (_index, entry) => {
+      // Catches a partial edit when the API host is swapped to a custom domain.
+      const { origin } = new URL(entry.anchor);
+      const relations = ["service-desc", "service-doc", "status"];
+      const hrefs = relations.flatMap(relation => linksFor(entry, relation) ?? []).map(link => link.href);
+
+      for (const href of hrefs) {
+        expect(new URL(href).origin).toBe(origin);
+      }
+    },
+  );
+});
+
+describe("api catalog _headers rule", () => {
+  it("serves the catalog as application/linkset+json", () => {
+    const rule = headers
+      .split(/\n(?=\S)/)
+      .find(block => block.startsWith("/.well-known/api-catalog"));
+
+    expect(rule, "public/_headers is missing a /.well-known/api-catalog block").toBeDefined();
+    // Bare media type: a profile parameter is an RFC "SHOULD" and risks tripping
+    // validators that compare the Content-Type exactly.
+    expect(rule).toContain(`Content-Type: ${MEDIA_TYPE}\n`);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,6 +35,9 @@ export default defineConfig(({ mode }) => ({
       registerType: 'autoUpdate',
       workbox: {
         globPatterns: ['**/*.{js,css,html,ico,png,svg}'],
+        // Well-known URIs (RFC 8615) must reach the network, not the SPA shell.
+        // Without this, navigating to /.well-known/api-catalog returns index.html.
+        navigateFallbackDenylist: [/^\/\.well-known\//],
         runtimeCaching: [{
           urlPattern: /^https:\/\/api\.github\.com\/.*/i,
           handler: 'CacheFirst',


### PR DESCRIPTION
Makes the Unified Portfolio API discoverable to agents per [RFC 9727](https://www.rfc-editor.org/rfc/rfc9727). Nothing on `timdehof.dev` previously pointed at the API, so an agent landing here had no way to find it.

**This is already live** — deployed and validated before this PR. Merging aligns `main` with production; the committed catalog is byte-identical to what the site serves right now.

## Changes

| File | Change |
|---|---|
| `public/.well-known/api-catalog` | Linkset document (RFC 9727 §A.1) — one entry anchored at `https://api.timdehof.dev/api` with `service-desc` (OpenAPI 3.1), `service-doc` (Scalar) and `status` (health) |
| `public/_headers` | `Content-Type: application/linkset+json`, caching and CORS for that path |
| `index.html` | `<link rel="api-catalog">` |
| `tests/api-catalog.test.ts` | 4 tests: linkset shape, absolute https hrefs, href/anchor origin consistency, and the `_headers` media-type rule |
| `vite.config.ts` | `navigateFallbackDenylist: [/^\/\.well-known\//]` |

## Two non-obvious details

**The media type has to come from `_headers`.** The catalog is extensionless, so wrangler uploads it as `application/octet-stream`. The `_headers` override was verified under `wrangler dev` before deploying, not assumed.

**The bare media type is deliberate.** RFC 9727 makes the `profile` parameter a SHOULD, but a validator may compare `Content-Type` exactly. It passes without it; the test pins the bare form so it doesn't drift.

**The service worker needed a denylist.** Workbox's `NavigationRoute` is bound to `index.html` with no exclusions, so a browser *navigating* to the catalog (with the SW installed) got the SPA shell. `fetch()` and scanners were unaffected — which is why it passed validation even before this fix.

## Verification

`checks.discovery.apiCatalog.status` is `"pass"` from `isitagentready.com`, with `correctContentType: true` and 1 API listed.

Worth noting for reviewers: **HTTP 200 proves nothing here.** `not_found_handling = "single-page-application"` returns 200 + `index.html` for any missing path, so checks assert the media type *and* parse the body.

All 112 tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a standards-compliant API catalog at `/.well-known/api-catalog`.
  - Linked the catalog to the Unified Portfolio API’s OpenAPI specification, reference documentation, and health-check endpoint.
  - Enabled cross-origin access and one-hour caching for the catalog.

- **Bug Fixes**
  - API catalog requests now reach the correct endpoint instead of being redirected to the application shell.

- **Tests**
  - Added coverage validating catalog structure, links, headers, and hosting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR publishes an RFC 9727 API catalog and exposes it through HTML discovery while ensuring Cloudflare and the service worker return the catalog rather than the SPA shell.
- Adds the extensionless Linkset catalog with API description, documentation, and health links.
- Configures its media type, caching, and cross-origin access through Cloudflare Pages headers.
- Excludes well-known navigation paths from Workbox's SPA fallback.
- Adds structural and header-source tests for the catalog.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issue identified.

The catalog, deployment headers, HTML discovery link, and service-worker exclusion form a consistent discovery path, and the investigated build and routing configurations do not expose a reachable failure.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| public/.well-known/api-catalog | Adds a valid Linkset catalog containing absolute HTTPS links for the API description, documentation, and health endpoint. |
| public/_headers | Assigns the required Linkset media type and adds caching and CORS headers for the extensionless catalog. |
| vite.config.ts | Prevents Workbox navigation fallback from replacing well-known resources with the SPA shell. |
| index.html | Advertises the catalog through a document-level api-catalog link relation. |
| tests/api-catalog.test.ts | Tests the catalog shape, HTTPS and origin invariants, and the source header rule without introducing an accepted defect. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Agent
    participant Site as timdehof.dev
    participant SW as Service Worker
    participant API as api.timdehof.dev
    Agent->>Site: GET /
    Site-->>Agent: "HTML with rel=api-catalog"
    Agent->>SW: GET /.well-known/api-catalog
    SW->>Site: Bypass navigation fallback
    Site-->>Agent: application/linkset+json
    Agent->>API: Fetch service-desc or service-doc
    API-->>Agent: API metadata
```

<sub>Reviews (1): Last reviewed commit: ["feat(discovery): publish RFC 9727 API ca..."](https://github.com/timdehof/myportfolio/commit/44bdf0aca1fb9f6894fc8a3ed22d378031302906) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51447746)</sub>

<!-- /greptile_comment -->