### PR TITLE
ci: add CI workflow and generate the sitemap at build time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,11 @@ jobs:
         with:
           submodules: recursive
 
+      # No `version:` input on purpose. package.json pins
+      # "packageManager": "pnpm@10.25.0", and action-setup hard-errors with
+      # "Multiple versions of pnpm specified" if both are given. Letting it
+      # read packageManager also keeps CI and local installs on one version.
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Lint, type-check, test, build
+    runs-on: ubuntu-latest
+
+    steps:
+      # The blog content is a submodule and the `prepare` script initialises it
+      # on install, so check it out up front rather than letting install do it.
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      # Advisory, not gating: the repo currently has ~866 pre-existing eslint
+      # errors (mostly unused exports, filename-case and formatting; ~785 are
+      # auto-fixable with `pnpm lint:fix`). Making this required today would
+      # mean a permanently red CI, which teaches people to ignore it. Flip
+      # continue-on-error off once the backlog is cleared.
+      - name: Lint (advisory)
+        run: pnpm lint
+        continue-on-error: true
+
+      - name: Type-check
+        run: pnpm type-check
+
+      - name: Test
+        run: pnpm exec vitest run
+
+      # Also proves public/.well-known/api-catalog and the generated sitemap
+      # survive the Vite + Cloudflare plugin pipeline into build/.
+      - name: Build
+        run: pnpm build
+
+      - name: Verify discovery files are in the build output
+        run: |
+          for f in .well-known/api-catalog sitemap.xml robots.txt _headers; do
+            if [ ! -f "build/$f" ]; then
+              echo "::error::build/$f is missing from the build output"
+              exit 1
+            fi
+            echo "ok: build/$f"
+          done
+
+      # The sitemap is generated at build time; a stale committed copy means
+      # someone changed routes or projectsIndex without rebuilding.
+      - name: Check the committed sitemap is current
+        run: git diff --exit-code -- public/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,31 +2,61 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://timdehof.dev/</loc>
-    <lastmod>2024-12-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://timdehof.dev/about</loc>
-    <lastmod>2024-12-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://timdehof.dev/projects</loc>
-    <lastmod>2024-12-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
+    <loc>https://timdehof.dev/blog</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://timdehof.dev/services</loc>
-    <lastmod>2024-12-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://timdehof.dev/contact</loc>
-    <lastmod>2024-12-01</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://timdehof.dev/projects/shadcn-timeline</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://timdehof.dev/projects/cognidocs</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://timdehof.dev/projects/roomify</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://timdehof.dev/projects/3d-product-configurator</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://timdehof.dev/projects/habitgate-mobile</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://timdehof.dev/projects/scanpic</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>

--- a/scripts/sitemap.ts
+++ b/scripts/sitemap.ts
@@ -1,0 +1,59 @@
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { projectsIndex } from "../src/data/projectsIndex";
+
+export const SITE_URL = "https://timdehof.dev";
+
+interface SitemapEntry {
+  path: string;
+  changefreq: string;
+  priority: string;
+}
+
+/**
+ * Every crawlable URL on the site.
+ *
+ * Deliberately no <lastmod>: the hand-maintained sitemap carried a stale
+ * 2024-12-01 for over a year, and stamping the build date would rewrite the
+ * file on every build. Search engines discount lastmod they cannot trust, so
+ * omitting it beats publishing a wrong one.
+ */
+export function buildEntries(): SitemapEntry[] {
+  const staticRoutes: SitemapEntry[] = [
+    { path: "/", changefreq: "monthly", priority: "1.0" },
+    { path: "/about", changefreq: "monthly", priority: "0.8" },
+    { path: "/projects", changefreq: "weekly", priority: "0.9" },
+    { path: "/blog", changefreq: "weekly", priority: "0.8" },
+    { path: "/services", changefreq: "monthly", priority: "0.8" },
+    { path: "/contact", changefreq: "monthly", priority: "0.7" },
+  ];
+
+  const projectRoutes: SitemapEntry[] = projectsIndex.map(entry => ({
+    path: `/projects/${entry.slug}`,
+    changefreq: "monthly",
+    priority: "0.7",
+  }));
+
+  return [...staticRoutes, ...projectRoutes];
+}
+
+export function renderSitemap(entries: SitemapEntry[]): string {
+  const urls = entries
+    .map(entry => [
+      "  <url>",
+      `    <loc>${SITE_URL}${entry.path}</loc>`,
+      `    <changefreq>${entry.changefreq}</changefreq>`,
+      `    <priority>${entry.priority}</priority>`,
+      "  </url>",
+    ].join("\n"))
+    .join("\n");
+
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n</urlset>\n`;
+}
+
+export function writeSitemap(publicDir: string): string {
+  const xml = renderSitemap(buildEntries());
+  writeFileSync(resolve(publicDir, "sitemap.xml"), xml, "utf8");
+  return xml;
+}

--- a/src/services/api/__tests__/github-stats.test.ts
+++ b/src/services/api/__tests__/github-stats.test.ts
@@ -40,8 +40,10 @@ describe("githubStatsAPI.fetchGitHubStats", () => {
     expect(stats.repositories.total).toBe(mockRepos.length);
     expect(stats.repositories.stars).toBe(8); // 5+2+1
     expect(stats.repositories.languages.length).toBeGreaterThan(0);
-    // Expect contributionYears to be sorted descending
-    expect(stats.activity.contributionYears).toEqual(["2023", "2022", "2021", "2020", "2019"]);
+    // Expect contributionYears to be sorted descending.
+    // Years come from the UTC instants of the fixture dates; the previous
+    // expectation included a phantom "2019" that only appeared west of UTC.
+    expect(stats.activity.contributionYears).toEqual(["2023", "2022", "2021", "2020"]);
   });
 
   it("should propagate errors from fetchUser", async () => {
@@ -169,8 +171,10 @@ describe("githubStatsAPI.calculateActivityStats", () => {
 
     const stats = githubStatsAPI.calculateActivityStats(mockRepos);
 
-    // Expect contributionYears to be sorted descending
-    expect(stats.contributionYears).toEqual(["2023", "2022", "2021", "2020"]);
+    // Expect contributionYears to be sorted descending.
+    // Fixture years in UTC are {2023, 2022, 2021}; the previous "2020" was an
+    // artifact of reading UTC-midnight dates back in a negative-offset zone.
+    expect(stats.contributionYears).toEqual(["2023", "2022", "2021"]);
     expect(stats.totalCommits).toBe(mockRepos.length * 10);
     expect(stats.currentStreak).toBe(3); // 3 recent activities
     expect(stats.longestStreak).toBe(mockRepos.length); // Estimated
@@ -189,8 +193,11 @@ describe("githubStatsAPI.calculateActivityStats", () => {
 describe("githubStatsAPI.generateContributionCalendar", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Consistent date for testing for a full year
-    const mockDate = new Date("2024-12-31T12:00:00Z");
+    // Consistent date for testing for a full year.
+    // Constructed in local time on purpose: generateContributionCalendar works
+    // entirely in local time, and a UTC instant of 2024-12-31T12:00Z is already
+    // 2025-01-01 east of UTC+12, which collapses the calendar to a single week.
+    const mockDate = new Date(2024, 11, 31, 12, 0, 0);
     vi.useFakeTimers();
     vi.setSystemTime(mockDate);
   });

--- a/src/services/api/github-stats.ts
+++ b/src/services/api/github-stats.ts
@@ -196,11 +196,15 @@ export const githubStatsAPI = {
 
   // Calculate activity statistics (simplified version)
   calculateActivityStats: (repositories: GitHubRepository[]) => {
-    // Get unique years from repository creation/update dates
+    // Get unique years from repository creation/update dates.
+    // GitHub timestamps are UTC, and date-only strings ("2020-01-01") parse as
+    // UTC midnight, so read them back with getUTCFullYear. getFullYear would
+    // reinterpret that instant in the viewer's zone and report the previous
+    // year for anyone west of UTC.
     const years = new Set<string>();
     repositories.forEach((repo) => {
-      years.add(new Date(repo.created_at).getFullYear().toString());
-      years.add(new Date(repo.updated_at).getFullYear().toString());
+      years.add(new Date(repo.created_at).getUTCFullYear().toString());
+      years.add(new Date(repo.updated_at).getUTCFullYear().toString());
     });
 
     // Simplified activity calculation based on repository updates

--- a/tests/sitemap.test.ts
+++ b/tests/sitemap.test.ts
@@ -1,0 +1,56 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { buildEntries, renderSitemap, SITE_URL } from "../scripts/sitemap";
+import { projectsIndex } from "../src/data/projectsIndex";
+
+const SITEMAP_PATH = resolve(__dirname, "../public/sitemap.xml");
+const ROUTES_DIR = resolve(__dirname, "../src/routes");
+
+const sitemap = readFileSync(SITEMAP_PATH, "utf8");
+const locs = [...sitemap.matchAll(/<loc>([^<]+)<\/loc>/g)].map(m => m[1]);
+
+describe("sitemap", () => {
+  it("is in sync with the generator", () => {
+    // Fails if someone hand-edits public/sitemap.xml or forgets to rebuild
+    // after changing the route list.
+    expect(sitemap).toBe(renderSitemap(buildEntries()));
+  });
+
+  it("covers every file-based route", () => {
+    // Derived from the filesystem so a new route that nobody adds to the
+    // generator fails here rather than silently going unindexed.
+    const routePaths = readdirSync(ROUTES_DIR)
+      .filter(f => f.endsWith(".tsx") && !f.startsWith("__"))
+      .map(f => f.replace(/\.(lazy\.)?tsx$/, ""))
+      // projects.$slug is covered by the per-project URLs below
+      .filter(f => !f.includes("$"))
+      .map(f => (f === "index" ? "/" : `/${f.replace(/\./g, "/")}`));
+
+    for (const path of routePaths) {
+      expect(locs, `${path} missing from sitemap`).toContain(`${SITE_URL}${path}`);
+    }
+  });
+
+  it("lists every project detail page", () => {
+    for (const { slug } of projectsIndex) {
+      expect(locs, `${slug} missing from sitemap`).toContain(`${SITE_URL}/projects/${slug}`);
+    }
+  });
+
+  it("uses absolute https URLs with no duplicates", () => {
+    expect(locs.length).toBeGreaterThan(0);
+    expect(new Set(locs).size).toBe(locs.length);
+
+    for (const loc of locs) {
+      expect(new URL(loc).protocol).toBe("https:");
+      expect(loc.startsWith(SITE_URL)).toBe(true);
+    }
+  });
+
+  it("matches the host robots.txt advertises", () => {
+    const robots = readFileSync(resolve(__dirname, "../public/robots.txt"), "utf8");
+    expect(robots).toContain(`Sitemap: ${SITE_URL}/sitemap.xml`);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,10 +8,21 @@ import tailwindcss from '@tailwindcss/vite';
 import {visualizer} from "rollup-plugin-visualizer";
 import { cloudflare } from "@cloudflare/vite-plugin";
 import { tanstackRouter } from '@tanstack/router-plugin/vite';
+import { writeSitemap } from './scripts/sitemap';
+
+// Regenerates public/sitemap.xml from the route list and projectsIndex before
+// each build, so adding a project cannot leave the sitemap behind again.
+const sitemap = () => ({
+  name: 'generate-sitemap',
+  buildStart() {
+    writeSitemap(resolve(__dirname, 'public'));
+  },
+});
 
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => ({
   plugins: [
+    sitemap(),
     visualizer({
       emitFile: true,
       filename: 'stats.html',


### PR DESCRIPTION
Two loose ends from the API catalog work.

## The sitemap was stale, so generate it instead

`public/sitemap.xml` was hand-maintained: 5 URLs, `lastmod 2024-12-01`, missing `/blog` and all six project detail pages. Patching it by hand would just let it drift again, so a Vite plugin now generates it at `buildStart` from the route list and `projectsIndex`. **5 URLs → 12.**

Two deliberate choices:

- **No `<lastmod>`.** Stamping the build date would rewrite the file on every build; a wrong lastmod is worse than none, since search engines discount values they can't trust.
- **Generation is deterministic** — verified across repeat builds, which is what lets CI assert the committed file is current.

`tests/sitemap.test.ts` checks the committed file matches the generator, **derives expected routes from `src/routes/`** so a new route nobody adds fails loudly rather than going unindexed, and asserts the host matches what `robots.txt` advertises.

## CI

Nothing ran the test suite on a PR — the tests guarding the API catalog only protected whoever remembered to run them locally. The workflow runs type-check, tests and build, then verifies the discovery files (`.well-known/api-catalog`, `sitemap.xml`, `robots.txt`, `_headers`) actually survived the Vite + Cloudflare plugin pipeline into `build/`.

**Lint is advisory, not gating.** The repo has ~866 pre-existing eslint errors (mostly unused exports, filename-case, formatting; ~785 auto-fixable via `pnpm lint:fix`). Requiring it today means a permanently red CI, which teaches people to ignore the signal. There's a comment saying to flip `continue-on-error` off once that's cleared — worth its own PR, since a repo-wide autofix would be a huge diff.

## Verified locally

- type-check clean, **117 tests pass** (18 files, up from 112/17)
- build succeeds; all four discovery files present in `build/`
- sitemap byte-identical across two consecutive builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a CI workflow and generates the committed sitemap from static routes and project metadata during Vite builds.
- Runs lint, type-checking, tests, build validation, and discovery-file checks in CI.
- Adds deterministic sitemap generation and coverage tests.
- Corrects timezone-sensitive GitHub activity tests and UTC year extraction.

<h3>Confidence Score: 3/5</h3>

The PR should not merge until the CI workflow pins each external action to an immutable commit SHA.

The workflow still executes checkout, pnpm setup, and Node setup from movable tags, allowing upstream tag changes to alter trusted CI code and access the runner environment.

**Files Needing Attention:** .github/workflows/ci.yml

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Adds the validation pipeline, but its external actions remain referenced through mutable tags. |
| scripts/sitemap.ts | Adds deterministic sitemap entry construction, rendering, and file generation. |
| tests/sitemap.test.ts | Verifies generator synchronization, current file-based routes, project pages, URL properties, and robots.txt host consistency. |
| vite.config.ts | Registers sitemap generation before Vite builds. |
| src/services/api/github-stats.ts | Uses UTC years when deriving activity years from GitHub timestamps. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  R[Static routes] --> G[buildEntries]
  P[projectsIndex] --> G
  G --> S[renderSitemap]
  S --> W[public/sitemap.xml]
  W --> V[Vite build]
  V --> B[build/sitemap.xml]
  C[CI checks] --> V
  C --> D[Discovery-file validation]
```

<sub>Reviews (3): Last reviewed commit: ["fix(github-stats): read GitHub timestamp..."](https://github.com/timdehof/myportfolio/commit/da9b9ab44eb120fb39720f500826beeb26510809) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51449733)</sub>

<!-- /greptile_comment -->