### PR TITLE
ci: deploy the site from main instead of by hand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
   workflow_dispatch:
 
+# This workflow runs fork-authored code on pull_request, and the repo now holds
+# a deployment secret for deploy.yml. pull_request never exposes secrets to
+# forks, but state the token scope explicitly rather than relying on the
+# account default staying read-only.
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,95 @@
+name: Deploy
+
+# Deploys the site on every push to main. This exists because main silently
+# drifted from production once already: the generated sitemap and the eslint
+# cleanup were merged and then sat unpublished, because deploying was a manual
+# `pnpm deploy:worker` that nobody remembered to run.
+#
+# Requires a CLOUDFLARE_API_TOKEN repository secret ("Edit Cloudflare Workers"
+# template). The account ID comes from wrangler.toml.
+#
+# NOTE: this repository is public. Never add a pull_request or
+# pull_request_target trigger here — pull_request_target would run fork-authored
+# code with access to that secret. Untrusted code belongs in ci.yml, which has
+# no secrets and only a read-scoped token.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Explicit rather than inherited: the repo default is read-only today, but this
+# workflow now sits next to a deployment credential, so the intent should be in
+# the file rather than in a dashboard setting someone can flip.
+permissions:
+  contents: read
+
+# Never let two deploys race; queue rather than cancel, so the last push wins
+# and no build is dropped halfway.
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Verify and deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      # The blog content is a submodule and the build reads it.
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      # The same gates as CI. Duplicated deliberately: a deploy should stand on
+      # its own rather than trust that some earlier run was green.
+      - name: Lint
+        run: pnpm lint
+
+      - name: Type-check
+        run: pnpm type-check
+
+      - name: Test
+        run: pnpm exec vitest run
+
+      - name: Build
+        run: pnpm build
+
+      # A missing discovery file is invisible until an agent or crawler looks,
+      # which is exactly the failure mode this repo keeps hitting.
+      - name: Verify discovery files are in the build output
+        run: |
+          for f in .well-known/api-catalog sitemap.xml robots.txt _headers; do
+            if [ ! -f "build/$f" ]; then
+              echo "::error::build/$f is missing from the build output"
+              exit 1
+            fi
+            echo "ok: build/$f"
+          done
+
+      - name: Check the committed sitemap is current
+        run: git diff --exit-code -- public/sitemap.xml
+
+      - name: Require API token
+        env:
+          TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          if [ -z "$TOKEN" ]; then
+            echo "::error::CLOUDFLARE_API_TOKEN is not set. Add it under Settings > Secrets and variables > Actions."
+            exit 1
+          fi
+
+      - name: Deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
`main` drifted from production once already today: the generated sitemap and the eslint cleanup were merged, then sat unpublished because deploying was a manual `pnpm deploy:worker` nobody remembered to run. The `stack-health` cron is what caught it — not the cheapest way to find out your site is stale.

## What it does

Deploys on push to `main`, gated behind **lint → type-check → tests → build**, then asserts:

- the four discovery files (`.well-known/api-catalog`, `sitemap.xml`, `robots.txt`, `_headers`) actually reached `build/`
- the committed sitemap matches what the build regenerates

Those gates are duplicated from `ci.yml` deliberately — a deploy should stand on its own rather than trust that some earlier run happened to be green.

## Security, because this repo is public

This is the first time `myPortfolio` will hold a secret, which changes the calculus. The security review earlier flagged exactly this as the condition that would make the setup unsafe, so:

- **`deploy.yml` has no `pull_request` trigger, and must never gain one.** `pull_request_target` especially would run fork-authored code with access to the deployment token. Untrusted code stays in `ci.yml`, which has no secrets.
- **Both workflows now declare `permissions: contents: read`.** The account default is already read-only — but that's a dashboard setting someone can flip, and the intent belongs in the file.
- No `${{ }}` interpolation in any `run:` block; the token is passed via `env:` and only tested for emptiness.

Also: **no `version:` input on `pnpm/action-setup`.** `package.json` pins `packageManager`, and supplying both makes the action fail outright — that's what broke the very first CI run in this repo.

## Before this does anything

Add a **`CLOUDFLARE_API_TOKEN`** repository secret. The same token you created for `portfolio-tools` works — it's account-scoped and `myportfolio` is on that account. Until then the deploy step fails with an explicit message rather than silently doing nothing.

Merging this will trigger a deploy of whatever is on `main` — which is exactly what's live right now, so it should be a no-op that proves the pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated deployment for changes pushed to the main branch, with an option to trigger deployments manually.
  * Deployments now run quality checks, verify required site files, confirm sitemap freshness, and publish through Cloudflare.
* **Chores**
  * Improved CI workflow security with explicit read-only repository permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds an independently gated deployment workflow for pushes to `main` and explicitly restricts both workflows to read-only repository permissions.
- Runs linting, type checking, tests, and the production build before deployment.
- Verifies discovery artifacts and the committed sitemap before invoking Cloudflare Wrangler.
- Serializes deployments and fails clearly when the Cloudflare API token is absent.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with one non-blocking supply-chain hardening opportunity around the credential-bearing deployment action reference.

The deployment flow matches the existing worker command and correctly validates generated artifacts, but pinning the Wrangler action to an immutable commit would better protect the newly introduced Cloudflare credential.

**Files Needing Attention:** .github/workflows/deploy.yml

<details open><summary><h3>Security Review</h3></summary>

The deployment credential is scoped to the deployment workflow, but the action receiving it is referenced by a mutable major-version tag. Pinning `cloudflare/wrangler-action` to a reviewed full commit SHA would remove this supply-chain tag-retargeting path.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Adds an explicit read-only contents permission to the existing untrusted-code CI workflow. |
| .github/workflows/deploy.yml | Adds a comprehensive push-to-main deployment pipeline; the credential-bearing deployment action remains referenced through a mutable major-version tag. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Push to main or manual dispatch] --> B[Checkout with submodules]
    B --> C[Install dependencies]
    C --> D[Lint]
    D --> E[Type-check]
    E --> F[Tests]
    F --> G[Build]
    G --> H[Verify discovery files]
    H --> I[Verify committed sitemap]
    I --> J[Require Cloudflare token]
    J --> K[Deploy with Wrangler action]
```

<sub>Reviews (1): Last reviewed commit: ["ci: deploy the site from main instead of..."](https://github.com/timdehof/myportfolio/commit/fd1ae6044701be7083986e0ce63fadca553fa25e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51507822)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->