### PR TITLE
fix(ci): supply the Cloudflare account ID to the deploy step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,16 +80,29 @@ jobs:
       - name: Check the committed sitemap is current
         run: git diff --exit-code -- public/sitemap.xml
 
-      - name: Require API token
+      - name: Require deployment credentials
         env:
           TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          ACCOUNT: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          if [ -z "$TOKEN" ]; then
-            echo "::error::CLOUDFLARE_API_TOKEN is not set. Add it under Settings > Secrets and variables > Actions."
+          missing=""
+          [ -z "$TOKEN" ] && missing="CLOUDFLARE_API_TOKEN"
+          [ -z "$ACCOUNT" ] && missing="$missing CLOUDFLARE_ACCOUNT_ID"
+          if [ -n "$missing" ]; then
+            echo "::error::Missing secret(s):$missing. Add under Settings > Secrets and variables > Actions."
             exit 1
           fi
 
+      # accountId is supplied here rather than in wrangler.toml because this
+      # repository is public. wrangler.toml declares no account_id, so wrangler
+      # otherwise calls /memberships to discover the account — which an "Edit
+      # Cloudflare Workers" token cannot read, and the deploy fails with
+      # "Authentication failed [code: 9106]" after every gate has passed.
+      #
+      # An account ID is an identifier rather than a credential, but it costs
+      # nothing to keep it out of a public repo.
       - name: Deploy
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
The first automated deploy passed **every gate** — lint, type-check, tests, build, discovery-file check, sitemap freshness, token presence — and then failed at the wrangler step:

```
A request to the Cloudflare API (/memberships) failed.
Authentication failed (status: 400) [code: 9106]
```

## Cause

`wrangler.toml` declares no `account_id`, so wrangler calls `/memberships` to discover which account to deploy to. An **"Edit Cloudflare Workers" token cannot read that endpoint** — it's scoped to Workers, not account membership.

Every worker in `portfolio-tools` sets `account_id` in its `wrangler.toml`, which is why those deploy cleanly with the same token. `myPortfolio` never needed it because every deploy until now was local, where wrangler uses OAuth and already knows the account.

## Fix

Passes the account ID as a `wrangler-action` input from a `CLOUDFLARE_ACCOUNT_ID` secret rather than committing it to `wrangler.toml`, **because this repository is public**. An account ID is an identifier and not a credential, but there's no reason to publish it. Local deploys are unaffected — OAuth still resolves the account.

The preflight check now names whichever secret is missing rather than only testing the token, so the next person gets a useful error instead of a wrangler stack trace.

## Needs one more secret before this works

**`CLOUDFLARE_ACCOUNT_ID`** = `724cad62a2bf6e089c0ad207daba67e1` (the value already in every `portfolio-tools` `wrangler.toml`).

https://github.com/timDeHof/myPortfolio/settings/secrets/actions

Until it's set, the deploy fails at the preflight step with a clear message rather than deep inside wrangler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates the deployment workflow to provide Cloudflare’s account ID explicitly, avoiding account discovery with a token that cannot access memberships.
- Validates both required Cloudflare secrets before deployment and reports their names when missing.
- Passes `CLOUDFLARE_ACCOUNT_ID` through the supported `wrangler-action` input.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge and correctly addresses the Cloudflare account-discovery failure.

The credential preflight handles both required secrets, and the deployment action receives the account ID through its supported input without changing unrelated workflow behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/deploy.yml | Correctly validates the account ID secret and supplies it through wrangler-action’s supported `accountId` input. |

<sub>Reviews (1): Last reviewed commit: ["fix(ci): supply the Cloudflare account I..."](https://github.com/timdehof/myportfolio/commit/f89719a65de35d976d16329914796808a930ae1d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51508624)</sub>

<!-- /greptile_comment -->