### PR TITLE
chore: remove the unused Web3Forms access key

### DIFF
--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -4,7 +4,6 @@ import tryParseEnv from "./try-parse-env";
 
 const EnvSchema = z.object({
   VITE_NODE_ENV: z.string().default("development"),
-  VITE_WEB3FORMS_ACCESS_KEY: z.string().optional(),
   VITE_API_BASE_URL: z.string().url().default("https://api.timdehof.dev/api"),
   VITE_RESUME_URL: z.string().url().optional(),
 });
@@ -26,7 +25,6 @@ type EnvSchema = z.infer<typeof EnvSchema>;
  */
 const rawEnv: Record<string, string | undefined> = {
   VITE_NODE_ENV: import.meta.env.VITE_NODE_ENV || import.meta.env.MODE || "development",
-  VITE_WEB3FORMS_ACCESS_KEY: import.meta.env.VITE_WEB3FORMS_ACCESS_KEY,
   VITE_API_BASE_URL: import.meta.env.VITE_API_BASE_URL,
   VITE_RESUME_URL: import.meta.env.VITE_RESUME_URL,
 };

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -5,7 +5,6 @@
 // prefix, which means "safe to publish".
 interface ImportMetaEnv {
   readonly VITE_NODE_ENV?: string;
-  readonly VITE_WEB3FORMS_ACCESS_KEY?: string;
   readonly VITE_API_BASE_URL?: string;
   readonly VITE_RESUME_URL?: string;
 }


### PR DESCRIPTION
`VITE_WEB3FORMS_ACCESS_KEY` appeared in exactly three places — the Zod schema, the read in `env.ts`, and the type declaration in `vite-env.d.ts`. **No feature ever consumed it.** The contact form posts to `portfolio-api`, which sends through Resend.

So it was a credential sitting in `.env`, and in every developer's environment, supporting nothing.

## Why remove rather than leave it

Dead configuration that looks like a live integration is worse than no configuration — the next person keeps it working, keeps the key rotated, and reasons about a form integration that doesn't exist. It also meant a real credential was in the environment of anyone who cloned and followed the README.

It was never published: CI builds without `.env` and the variable was `.optional()`, so it never reached the bundle. Verified again after this change — 0 occurrences in `build/`.

## Changes

- `src/lib/env.ts` — schema entry and the read
- `src/vite-env.d.ts` — type declaration
- local `.env` (not in this diff — gitignored)

**Also delete the key itself in the Web3Forms dashboard**, since nothing uses it.

## Verified

lint, type-check, **117 tests**, build — all pass. Bundle contains no trace of the key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the unused `VITE_WEB3FORMS_ACCESS_KEY` from environment validation, runtime collection, and Vite type declarations.

- Keeps the active API and resume environment configuration unchanged.
- Aligns the declared environment contract with the variables actually consumed by the application.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the removed environment variable has no consumers and the active contact-form API configuration remains intact.

Repository usage confirms that the contact form posts through `VITE_API_BASE_URL`; no source, test, script, configuration, or documentation depends on the removed Web3Forms key.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/env.ts | Removes an unused optional schema field and runtime environment read without affecting existing consumers. |
| src/vite-env.d.ts | Removes the corresponding unused `ImportMetaEnv` declaration, keeping the type contract aligned with runtime configuration. |

<sub>Reviews (1): Last reviewed commit: ["chore: remove the unused Web3Forms acces..."](https://github.com/timdehof/myportfolio/commit/76094d2fedd650042774dfd5f09dd1e48469ef5e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51514362)</sub>

<!-- /greptile_comment -->